### PR TITLE
Fixed Rebalance rackaware script for Kafka 3.2.0

### DIFF
--- a/src/python/rebalance/README.md
+++ b/src/python/rebalance/README.md
@@ -7,9 +7,9 @@ This tool generates a reassignment plan that has two goals:
 - Redistribute the replicas of partitions of a topic across brokers in a manner such that all replicas of a partition are in separate Update Domains (UDs) & Fault Domains (FDs).
 - Balance the leader load across the cluster - The number of leaders assigned to each broker is more or less the same. 
 
-Once the reasignment plan is generated the user can execute this plan. Upon execution, the tool updates the zookeeper path '/admin/reassign_partitions' with the list of topic partitions and (if specified in the Json file) the list of their new assigned replicas. The controller listens to the path above. When a data change update is triggered, the controller reads the list of topic partitions and their assigned replicas from zookeeper. The control handles starting new replicas in RAR and waititing until the new replicas are in sync with the leader. At this point, the old replicas are stopped and the partition is removed from the '/admin/reassignpartitions' path. Note that these steps are async operations.
+Once the reassignment plan is generated the user can execute this plan. Upon execution, the tool updates the zookeeper path '/admin/reassign_partitions' with the list of topic partitions and (if specified in the Json file) the list of their new assigned replicas. The controller listens to the path above. When a data change update is triggered, the controller reads the list of topic partitions and their assigned replicas from zookeeper. The control handles starting new replicas in RAR and waititing until the new replicas are in sync with the leader. At this point, the old replicas are stopped and the partition is removed from the '/admin/reassignpartitions' path. Note that these steps are async operations.
 
-This tool is best suitable for execution on each of the following events:
+This tool is the best suitable for execution on each of the following events:
 - New cluster
 - Whenever a new topic/partition is created
 - Cluster is scaled up
@@ -18,7 +18,7 @@ Note for execution on existing clusters:
 When executing on a cluster with large data sizes, there will be a performance degradation while reassignment is taking place, due to data movement. 
 On large clusters, rebalance can take several hours. In such scenarios, it is recommended to execute rebalance by steps (by topic or by partitions of a topic).
 
-## Prequisites
+## Prerequisites
 The script relies on various python modules. If not installed already, you must manually install these prior to execution:
 ```
 sudo apt-get update

--- a/src/python/troubleshooting/README.MD
+++ b/src/python/troubleshooting/README.MD
@@ -15,15 +15,15 @@ Clone the repository on any HDInsight cluster node using the following command:
 git clone https://github.com/hdinsight/hdinsight-kafka-tools.git
 ```
 
-The scripts are be located under ```hdinsight-kafka-tools/src/python/troubleshooting``` and can be executed from any directory.
+The scripts are being located under ```hdinsight-kafka-tools/src/python/troubleshooting``` and can be executed from any directory.
 
-|Script|File|When to use|Description|
--------|----|-----------|-----------|
-|Kafka Performance Test|[kafka_perf_test.py](kafka_perf_test.py)|Anytime|A quick performance test for Kafka.|
-|Kafka Broker Status|[kafka_broker_status.py](kafka_broker_status.py)|Anytime|Reports Broker status for all Kafka Brokers.|
-|Kafka Restart Brokers|[kafka_restart_brokers.py](kafka_restart_brokers.py)|Post Kafka configuration update|Restarts Kafka brokers based on health check.|
-|Kafka Restart Controller|[kafka_restart_controller.py](kafka_restart_controller.py)|For clearing Kafka controller state for partition leadership issues|Restarts Kafka Broker that is the current controller.|
-|Kafka Topic Describe|[kafka_topic_describe.py](kafka_topic_describe.py)|Anytime|Wrapper script for Kafka Topic describe that takes care of all inputs.|
+| Script                   | File                                                       | When to use                                                         | Description                                                            |
+|--------------------------|------------------------------------------------------------|---------------------------------------------------------------------|------------------------------------------------------------------------|
+| Kafka Performance Test   | [kafka_perf_test.py](kafka_perf_test.py)                   | Anytime                                                             | A quick performance test for Kafka.                                    |
+| Kafka Broker Status      | [kafka_broker_status.py](kafka_broker_status.py)           | Anytime                                                             | Reports Broker status for all Kafka Brokers.                           |
+| Kafka Restart Brokers    | [kafka_restart_brokers.py](kafka_restart_brokers.py)       | Post Kafka configuration update                                     | Restarts Kafka brokers based on health check.                          |
+| Kafka Restart Controller | [kafka_restart_controller.py](kafka_restart_controller.py) | For clearing Kafka controller state for partition leadership issues | Restarts Kafka Broker that is the current controller.                  |
+| Kafka Topic Describe     | [kafka_topic_describe.py](kafka_topic_describe.py)         | Anytime                                                             | Wrapper script for Kafka Topic describe that takes care of all inputs. |
 
 
 ## Kafka Performance Test

--- a/src/python/troubleshooting/kafka_get_pid_status.py
+++ b/src/python/troubleshooting/kafka_get_pid_status.py
@@ -1,24 +1,27 @@
 """Script to report the status of the Kafka process on this current host.
 """
-import datetime, os, psutil
+import datetime
+import os
+import psutil
 
 kafka_pid_file = '/var/run/kafka/kafka.pid'
 
 if os.path.exists(kafka_pid_file):
-    with open(kafka_pid_file,"r") as kpf:
-         kafka_pid = kpf.readline().strip()
+    with open(kafka_pid_file, "r") as kpf:
+        kafka_pid = kpf.readline().strip()
     int_kafka_pid = int(kafka_pid)
     if int_kafka_pid > 0 and psutil.pid_exists(int_kafka_pid):
         kafka_process = psutil.Process(int_kafka_pid)
         kafka_process_status = kafka_process.status()
-        
-        #Reboot if Kafka process has been zombie for more than max_kafka_zombie_secs seconds
+
+        # Reboot if Kafka process has been zombie for more than max_kafka_zombie_secs seconds
         if kafka_process_status == psutil.STATUS_ZOMBIE:
             print('ERROR: Kafka process with pid [{0}] is in a zombie state: {1}'.
-                format(kafka_pid, kafka_process_status))
+                  format(kafka_pid, kafka_process_status))
         else:
             print('SUCCESS: Verification of Kafka successful! Kafka pid: {0}, status: {1}, create_time: {2}'.
-                format(kafka_pid, kafka_process_status, datetime.datetime.fromtimestamp(kafka_process.create_time()).strftime("%Y-%m-%d %H:%M:%S")))
+                  format(kafka_pid, kafka_process_status,
+                         datetime.datetime.fromtimestamp(kafka_process.create_time()).strftime("%Y-%m-%d %H:%M:%S")))
     else:
         print('ERROR: Kafka is not running. Invalid pid file: {0}, pid: {1}'.format(kafka_pid_file, int_kafka_pid))
 else:

--- a/src/python/troubleshooting/kafka_perf_test.py
+++ b/src/python/troubleshooting/kafka_perf_test.py
@@ -1,11 +1,13 @@
 ﻿"""A script to perform a quick Kafka Performance test.
 """
-import logging, time
+import logging
+import time
 
 from kafka_utils import KafkaUtils
 
 logger = logging.getLogger(__name__)
 debug = False
+
 
 def get_kafka_shell_inputs(utils):
     """Gets the inputs for Kafka Shell. Takes KafkaUtils class object as the input.
@@ -19,77 +21,134 @@ def get_kafka_shell_inputs(utils):
     threads = min(4, partitions)
     messagesize = 100 Bytes
     batchsize = 10000
+    thoughput = -1
     """
     zookeepers = utils.get_zookeeper_quorum()
     broker_hosts, brokers = utils.get_brokers_from_ambari()
     broker_hosts_count = len(broker_hosts)
 
     utils.logger.info('Choosing defaults:')
-    partitions=broker_hosts_count
-    replicationfactor=min(3,broker_hosts_count)
-    messages=(partitions*1000000)
-    threads=min(4,partitions)
-    messagesize=100
-    batchsize=10000
+    partitions = broker_hosts_count
+    replicationfactor = min(3, broker_hosts_count)
+    messages = (partitions * 1000000)
+    threads = min(4, partitions)
+    messagesize = 100
+    batchsize = 10000
+    throughput = -1
 
-    logger.info('\n' + 
-        'zookeepers = {0}\n'.format(zookeepers) +
-        'brokers = {0}\n'.format(brokers) +
-        'partitions = {0}\n'.format(partitions) +
-        'replicationfactor = {0}\n'.format(replicationfactor) +
-        'messages = {0}\n'.format(messages) +
-        'threads = {0}\n'.format(threads) +
-        'messagesize = {0}\n'.format(messagesize) +
-        'batchsize = {0}\n'.format(batchsize)
-    )
+    logger.info('\n' +
+                'zookeepers = {0}\n'.format(zookeepers) +
+                'brokers = {0}\n'.format(brokers) +
+                'partitions = {0}\n'.format(partitions) +
+                'replicationfactor = {0}\n'.format(replicationfactor) +
+                'messages = {0}\n'.format(messages) +
+                'threads = {0}\n'.format(threads) +
+                'messagesize = {0}\n'.format(messagesize) +
+                'batchsize = {0}\n'.format(batchsize) +
+                'thoughput = {0}\n'.format(throughput)
+                )
 
-    return zookeepers, brokers, partitions, replicationfactor, messages, threads, messagesize, batchsize
+    return zookeepers, brokers, partitions, replicationfactor, messages, threads, messagesize, batchsize, throughput
+
 
 def main(utils, topic):
-    zookeepers, brokers, partitions, replicationfactor, messages, threads, messagesize, batchsize = get_kafka_shell_inputs(utils)
+    zookeepers, brokers, partitions, replicationfactor, messages, threads, messagesize, batchsize, throughput = \
+        get_kafka_shell_inputs(utils)
+    kafka_version, hdi_version = utils.get_kafka_hdp_version()
+    if kafka_version >= '3.2.0':
+        # Create
+        logger.info("Creating topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --create --bootstrap-server {0} --topic {1} " \
+                        "--partitions {2} --replication-factor {3}".format(brokers, topic, partitions,
+                                                                           replicationfactor)
+        utils.run_shell_command(shell_command)
 
-    #Create
-    logger.info("Creating topic: {0}".format(topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --create --zookeeper {0} --topic {1} --partitions {2} --replication-factor {3}".format(
-        zookeepers, topic, partitions, replicationfactor)
-    utils.run_shell_command(shell_command)
+        # List
+        logger.info("Listing topics")
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --list --bootstrap-server {0}".format(
+            brokers)
+        utils.run_shell_command(shell_command)
 
-    #List
-    logger.info("Listing topics")
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --list --zookeeper {0}".format(zookeepers)
-    utils.run_shell_command(shell_command)
+        # Describe
+        logger.info("Describing topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --bootstrap-servers {0} --topic " \
+                        "{1}".format(brokers, topic)
+        utils.run_shell_command(shell_command)
 
-    #Describe
-    logger.info("Describing topic: {0}".format(topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --zookeeper {0} --topic {1}".format(zookeepers, topic)
-    utils.run_shell_command(shell_command)
+        # Produce
+        logger.info("Producing {0} messages to topic {1}".format(messages, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh --topic {0} " \
+                        "--num-records {1} --record-size {2} --throughput {3} --producer-props acks=0 " \
+                        "bootstrap.servers={4} batch.size={5}".format(topic, messages, messagesize, throughput,
+                                                                      brokers, batchsize)
+        utils.run_shell_command(shell_command)
 
-    #Produce
-    logger.info("Producing {0} messages to topic {1}".format(messages, topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh --broker-list {0} --topics {1} --messages {2} --message-size {3} --batch-size {4} --request-num-acks 0 --compression-codec 0 --threads {5}".format(
-        brokers, topic, messages, messagesize, batchsize, threads)
-    utils.run_shell_command(shell_command)
+        # Offset
+        partitions_list = ",".join(map(str, range(0, partitions)))
+        logger.info("Listing offsets of partitions {0} of topic {1}".format(partitions_list, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-run-class.sh kafka.tools.GetOffsetShell " \
+                        "--bootstrap-server {0} --topic {1} --partitions {2} --time -1".\
+            format(brokers, topic, partitions_list)
+        utils.run_shell_command(shell_command)
 
-    #Offset
-    partitions_list = ",".join(map(str, range(0,partitions)))
-    logger.info("Listing offsets of partitions {0} of topic {1}".format(partitions_list, topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list {0} --topic {1} --partitions {2} --time -1 --offsets 1".format(
-        brokers, topic, partitions_list)
-    utils.run_shell_command(shell_command)
+        # Consume
+        logger.info("Consuming {0} messages from topic {1}".format(messages, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-consumer-perf-test.sh --bootstrap-server {0} -messages" \
+                        " {1} --topic {2} --threads {3}".format(brokers, messages, topic, threads)
+        utils.run_shell_command(shell_command)
 
-    #Consume
-    logger.info("Consuming {0} messages from topic {1}".format(messages, topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-consumer-perf-test.sh --zookeeper {0} -messages {1} --topic {2} --threads {3}".format(
-        zookeepers, messages, topic, threads)
-    utils.run_shell_command(shell_command)
+        # Delete
+        logger.info("Deleting topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --delete --bootstrap-server {0} --topic {1}" \
+            .format(brokers, topic)
+        utils.run_shell_command(shell_command)
+    else:
+        # Create
+        logger.info("Creating topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --create --zookeeper {0} --topic {1} " \
+                        "--partitions {2} --replication-factor {3}".format(zookeepers, topic, partitions,
+                                                                           replicationfactor)
+        utils.run_shell_command(shell_command)
 
-    #Delete
-    logger.info("Deleting topic: {0}".format(topic))
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --delete --zookeeper {0} --topic {1}".format(
-        zookeepers, topic)
-    utils.run_shell_command(shell_command)
-    
+        # List
+        logger.info("Listing topics")
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --list --zookeeper {0}".format(zookeepers)
+        utils.run_shell_command(shell_command)
+
+        # Describe
+        logger.info("Describing topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --zookeeper {0} --topic {1}". \
+            format(zookeepers, topic)
+        utils.run_shell_command(shell_command)
+
+        # Produce
+        logger.info("Producing {0} messages to topic {1}".format(messages, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-producer-perf-test.sh --broker-list {0} --topics {1} " \
+                        "--messages {2} --message-size {3} --batch-size {4} --request-num-acks 0 --compression-codec 0 " \
+                        "--threads {5}".format(brokers, topic, messages, messagesize, batchsize, threads)
+        utils.run_shell_command(shell_command)
+
+        # Offset
+        partitions_list = ",".join(map(str, range(0, partitions)))
+        logger.info("Listing offsets of partitions {0} of topic {1}".format(partitions_list, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-run-class.sh kafka.tools.GetOffsetShell --broker-list " \
+                        "{0} --topic {1} --partitions {2} --time -1 --offsets 1".format(brokers, topic, partitions_list)
+        utils.run_shell_command(shell_command)
+
+        # Consume
+        logger.info("Consuming {0} messages from topic {1}".format(messages, topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-consumer-perf-test.sh --zookeeper {0} -messages {1} " \
+                        "--topic {2} --threads {3}".format(zookeepers, messages, topic, threads)
+        utils.run_shell_command(shell_command)
+
+        # Delete
+        logger.info("Deleting topic: {0}".format(topic))
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --delete --zookeeper {0} --topic {1}".format(
+            zookeepers, topic)
+        utils.run_shell_command(shell_command)
+
+
 if __name__ == '__main__':
-    topic="kafkaperftest{0}".format(int(time.time()))
+    topic = "kafkaperftest{0}".format(int(time.time()))
     utils = KafkaUtils(logger, topic + ".log", debug)
     main(utils, topic)

--- a/src/python/troubleshooting/kafka_restart_brokers.py
+++ b/src/python/troubleshooting/kafka_restart_brokers.py
@@ -1,9 +1,12 @@
 ﻿"""Script to restart Kafka Brokers ensuring High Availability of brokers
 """
-import argparse, logging, pprint, sys, time
+import argparse
+import logging
+import pprint
+import time
 
-from kafka_utils import KafkaUtils
 from kafka_broker_status import get_kafka_broker_status, str_kafka_brokers_status
+from kafka_utils import KafkaUtils
 
 logger = logging.getLogger(__name__)
 debug = False
@@ -11,6 +14,7 @@ debug = False
 TIMEOUT_SECS = 3600
 WAIT_SECS = 300
 SLEEP_SECS = 30
+
 
 def main(args, utils):
     force = args.force
@@ -29,14 +33,15 @@ def main(args, utils):
     if len(restart_broker_hosts) == 0:
         logger.debug('No Brokers with stale configs found to restart.')
     else:
-        logger.info('Restarting brokers on following hosts: {0}\n{1}\n'.format(len(restart_broker_hosts), pprint.pformat(restart_broker_hosts)))
+        logger.info('Restarting brokers on following hosts: {0}\n{1}\n'.format(len(restart_broker_hosts),
+                                                                               pprint.pformat(restart_broker_hosts)))
 
     for restart_broker_host in restart_broker_hosts:
         broker_hosts, zk_brokers, dead_broker_hosts = get_kafka_broker_status(utils)
 
         if len(dead_broker_hosts) > 0:
             logger.warn('Dead/Unregistered brokers: {0}\n{1}\n'.
-                format(len(dead_broker_hosts), pprint.pformat(dead_broker_hosts)))
+                        format(len(dead_broker_hosts), pprint.pformat(dead_broker_hosts)))
             if not force:
                 err_msg = 'One or more brokers are not online, cannot proceed with broker restarts.'
                 logger.error(err_msg)
@@ -44,21 +49,27 @@ def main(args, utils):
             else:
                 logger.info('Forcing restart of brokers inspite of dead or unregistered brokers.')
         else:
-            logger.debug('All brokers are online and registered in Zookeeper, proceeding with restarts of stale Kafka Broker on {0}.'.format(restart_broker_host))
+            logger.debug(
+                'All brokers are online and registered in Zookeeper, proceeding with restarts of stale Kafka Broker '
+                'on {0}.'.format(
+                    restart_broker_host))
 
         utils.restart_kafka_broker_from_ambari(restart_broker_host)
         zk_brokers = utils.get_brokers_from_zookeeper()
         now = time.time()
         timeout = now + TIMEOUT_SECS
-        while(restart_broker_host not in zk_brokers):
+        while restart_broker_host not in zk_brokers:
             if time.time() > timeout:
-                err_msg = 'Kafka Broker on {0} failed to come online in Zookeeper in {1} secs. Please check the Kafka server log for potential issues'.format(restart_broker_host, TIMEOUT_SECS)
+                err_msg = 'Kafka Broker on {0} failed to come online in Zookeeper in {1} secs. Please check the Kafka ' \
+                          'server log for potential issues'.format(restart_broker_host, TIMEOUT_SECS)
                 logger.error(err_msg)
                 raise RuntimeError(err_msg)
-            logger.info('Kafka Broker on {0} is not yet online in Zookeper. Sleeping for {1} seconds...'.format(restart_broker_host, SLEEP_SECS))
+            logger.info('Kafka Broker on {0} is not yet online in Zookeeper. Sleeping for {1} seconds...'.format(
+                restart_broker_host, SLEEP_SECS))
             time.sleep(SLEEP_SECS)
             zk_brokers = utils.get_brokers_from_zookeeper()
-        logger.info('Kafka Broker on {0} sucessfully restarted and is now online in Zookeeper. Waiting for {1} seconds before proceeding to the next broker.'.format(restart_broker_host, WAIT_SECS))
+        logger.info( 'Kafka Broker on {0} successfully restarted and is now online in Zookeeper. Waiting for {1} '
+                     'seconds before proceeding to the next broker.'.format(restart_broker_host, WAIT_SECS))
         time.sleep(WAIT_SECS)
 
     logger.info('All brokers with stale configs have been restarted. Refreshing information...')
@@ -66,10 +77,14 @@ def main(args, utils):
     zk_brokers = utils.get_brokers_from_zookeeper()
     logger.info(str_kafka_brokers_status(broker_hosts, zk_brokers))
 
+
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Restart Kafka Brokers one by one and wait for their Zookeeper state to be alive.')
-    parser.add_argument('-f', '--force', action='store_true', help='Restart brokers with stale configs irrespective of their current health.')
-    parser.add_argument('-a', '--all', action='store_true', help='Restart all brokers one by one irrespective of their current health.')
+    parser = argparse.ArgumentParser(
+        description='Restart Kafka Brokers one by one and wait for their Zookeeper state to be alive.')
+    parser.add_argument('-f', '--force', action='store_true',
+                        help='Restart brokers with stale configs irrespective of their current health.')
+    parser.add_argument('-a', '--all', action='store_true',
+                        help='Restart all brokers one by one irrespective of their current health.')
     args = parser.parse_args()
     utils = KafkaUtils(logger, 'kafkarestartbrokers{0}.log'.format(int(time.time())), debug)
     main(args, utils)

--- a/src/python/troubleshooting/kafka_topic_describe.py
+++ b/src/python/troubleshooting/kafka_topic_describe.py
@@ -3,18 +3,28 @@ from kafka_utils import KafkaUtils
 
 logger = logging.getLogger(__name__)
 
+
 def main(utils):
     topic_name = ''
     if len(sys.argv) > 1:
         topic_name = sys.argv[1]
     logger.info('topic_name = ' + topic_name)
-    zookeeper_quorum = utils.get_zookeeper_quorum()
     logger.info('Listing topics')
-    shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --zookeeper {0}".format(zookeeper_quorum)
-    if(topic_name):
+    kafka_version, hdi_version = utils.get_kafka_hdp_version()
+    if kafka_version >= '3.2.0':
+        (_, broker_server) = utils.get_brokers_from_ambari()
+        logger.info(broker_server)
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --bootstrap-server {0}".format(
+            broker_server)
+    else:
+        zookeeper_quorum = utils.get_zookeeper_quorum()
+        shell_command = "/usr/hdp/current/kafka-broker/bin/kafka-topics.sh --describe --zookeeper {0}".format(
+            zookeeper_quorum)
+    if topic_name:
         shell_command += " --topic {0}".format(topic_name)
 
     stdout, stderr = utils.run_shell_command(shell_command)
+
 
 if __name__ == '__main__':
     utils = KafkaUtils(logger, "kafkatopicdescribe{0}.log".format(int(time.time())))


### PR DESCRIPTION
From Kafka 2.6 onwards Kafka partition reassignment tool command has started using broker hosts instead of zookeeper nodes.  So these kinds of commands were failing for 3.2.0
```
s = subprocess.check_output([
                KAFKA_REASSIGN_PARTITIONS_TOOL_PATH,
                "--zookeeper",
                get_zookeeper_connect_string(),
                "--reassignment-json-file",
                os.path.join(plan_directory, ASSIGNMENT_JSON_FILE),
                "--throttle",
                throttle_limit if throttle_limit else DEFAULT_REBALANCE_THROTTLE_RATE_BPS,
                "--execute"
            ])
```
**Fix command for both versions**

```
kafka_version, hdp_version = get_kafka_hdp_version()
        if kafka_version >= '3.2.0':
            s = subprocess.check_output([
                KAFKA_REASSIGN_PARTITIONS_TOOL_PATH,
                "--bootstrap-server",
                get_broker_connect_string(),
                "--reassignment-json-file",
                os.path.join(plan_directory, ASSIGNMENT_JSON_FILE),
                "--throttle",
                throttle_limit if throttle_limit else DEFAULT_REBALANCE_THROTTLE_RATE_BPS,
                "--execute"
            ])
            expected_output = "Successfully started partition reassignments"
        else:
            s = subprocess.check_output([
                KAFKA_REASSIGN_PARTITIONS_TOOL_PATH,
                "--zookeeper",
                get_zookeeper_connect_string(),
                "--reassignment-json-file",
                os.path.join(plan_directory, ASSIGNMENT_JSON_FILE),
                "--throttle",
                throttle_limit if throttle_limit else DEFAULT_REBALANCE_THROTTLE_RATE_BPS,
                "--execute"
            ])
```